### PR TITLE
feat(spend): Log API request spend.

### DIFF
--- a/libs/api/dev/src/api-dev.ts
+++ b/libs/api/dev/src/api-dev.ts
@@ -31,7 +31,5 @@ export const apiDev = new Elysia({ prefix: '/dev' })
     }
   })
   .get('/ping', () => ({ status: 'PONG' }), {
-    afterResponse: async ({ headers }) => {
-      await reportSpend({ apiKey: headers.authorization })
-    },
+    afterResponse: () => reportSpend({}),
   })

--- a/libs/api/dev/src/api-dev.ts
+++ b/libs/api/dev/src/api-dev.ts
@@ -3,6 +3,7 @@ import {
   ERROR_LIST,
   errorResponseModel,
   formatApiErrorResponse,
+  reportSpend,
   validateApiKey,
 } from '@nmit-coursition/api/utils'
 import { Elysia, t } from 'elysia'
@@ -29,4 +30,8 @@ export const apiDev = new Elysia({ prefix: '/dev' })
       throw error(ERROR_LIST[errorCode].code, formatApiErrorResponse(errorCode))
     }
   })
-  .get('/ping', 'PONG')
+  .get('/ping', () => ({ status: 'PONG' }), {
+    afterResponse: async ({ headers }) => {
+      await reportSpend({ apiKey: headers.authorization })
+    },
+  })

--- a/libs/api/dev/src/api-dev.ts
+++ b/libs/api/dev/src/api-dev.ts
@@ -1,6 +1,7 @@
 import {
   type ApiErrorCode,
   ERROR_LIST,
+  computeUsage,
   errorResponseModel,
   formatApiErrorResponse,
   reportSpend,
@@ -31,5 +32,8 @@ export const apiDev = new Elysia({ prefix: '/dev' })
     }
   })
   .get('/ping', () => ({ status: 'PONG' }), {
+    afterResponse: () => reportSpend({}),
+  })
+  .get('/report-usage', async () => await computeUsage({ organisationId: 1 }), {
     afterResponse: () => reportSpend({}),
   })

--- a/libs/api/utils/src/lib/api-utils.ts
+++ b/libs/api/utils/src/lib/api-utils.ts
@@ -2,10 +2,27 @@ import { prisma } from '@nmit-coursition/db'
 import { isDateBeforeNow } from '@nmit-coursition/utils'
 import { parseApiKey } from '../api'
 import type { ApiErrorCode } from '../errorList'
+import type { ApiKeyReportUsageRequest } from '../typescript'
+
+let API_KEY_TO_ID_CACHE: { [key: string]: bigint } = {}
 
 export function reportUsage(apiKey: string, duration: number, type: 'video' | 'document' | 'web') {
   // eslint-disable-next-line no-console -- will be replaced with real usage reporting
   console.log(`API Key ${apiKey} used ${duration} on ${type}.`)
+}
+
+export async function reportSpend({ apiKey, operationClass, spend, metaData }: ApiKeyReportUsageRequest) {
+  // eslint-disable-next-line no-console debug info
+  console.log(`🚀 Spend report (${operationClass || 'A'}): ${spend || 1}`)
+  await prisma.core__api_key_usage.create({
+    data: {
+      key_id: await resolveApiKeyIdByKey(apiKey),
+      operation_class: operationClass || 'A',
+      spend: Number(spend || 1),
+      inserted_date: new Date(),
+      ...(metaData ? { meta_data: metaData } : {}),
+    },
+  })
 }
 
 export async function validateApiKey(apiKey: string): Promise<ApiErrorCode | undefined> {
@@ -20,9 +37,23 @@ export async function validateApiKey(apiKey: string): Promise<ApiErrorCode | und
   if (key.is_deleted) return 'PUBLIC_API_KEY_HAS_BEEN_DELETED'
   if (!key.is_active) return 'PUBLIC_API_KEY_IS_NOT_ACTIVE'
   if (isDateBeforeNow(key.expiration_date)) return 'PUBLIC_API_KEY_HAS_BEEN_EXPIRED'
+  API_KEY_TO_ID_CACHE[apiKey] = key.id
 
   await incrementKeyUsage(key.id)
   return
+}
+
+export async function resolveApiKeyIdByKey(apiKey: string): Promise<bigint> {
+  const keyId: bigint | undefined = API_KEY_TO_ID_CACHE[apiKey as keyof typeof API_KEY_TO_ID_CACHE]
+  if (keyId) return keyId
+
+  const selectedKey = await prisma.cas__organisation_api_key.findFirstOrThrow({
+    select: { id: true },
+    where: { api_key: apiKey },
+  })
+  API_KEY_TO_ID_CACHE[apiKey] = selectedKey.id
+
+  return selectedKey.id
 }
 
 async function incrementKeyUsage(keyId: bigint) {

--- a/libs/api/utils/src/lib/api-utils.ts
+++ b/libs/api/utils/src/lib/api-utils.ts
@@ -6,17 +6,23 @@ import type { ApiKeyReportUsageRequest } from '../typescript'
 
 let API_KEY_TO_ID_CACHE: { [key: string]: bigint } = {}
 
+let API_KEY_CONTEXT: string | undefined
+
 export function reportUsage(apiKey: string, duration: number, type: 'video' | 'document' | 'web') {
   // eslint-disable-next-line no-console -- will be replaced with real usage reporting
   console.log(`API Key ${apiKey} used ${duration} on ${type}.`)
 }
 
 export async function reportSpend({ apiKey, operationClass, spend, metaData }: ApiKeyReportUsageRequest) {
+  const key = apiKey || API_KEY_CONTEXT
+  if (!key) throw new Error(`API key context has not been set. Please define apiKey.`)
+
   // eslint-disable-next-line no-console debug info
   console.log(`🚀 Spend report (${operationClass || 'A'}): ${spend || 1}`)
+
   await prisma.core__api_key_usage.create({
     data: {
-      key_id: await resolveApiKeyIdByKey(apiKey),
+      key_id: await resolveApiKeyIdByKey(key),
       operation_class: operationClass || 'A',
       spend: Number(spend || 1),
       inserted_date: new Date(),
@@ -38,6 +44,7 @@ export async function validateApiKey(apiKey: string): Promise<ApiErrorCode | und
   if (!key.is_active) return 'PUBLIC_API_KEY_IS_NOT_ACTIVE'
   if (isDateBeforeNow(key.expiration_date)) return 'PUBLIC_API_KEY_HAS_BEEN_EXPIRED'
   API_KEY_TO_ID_CACHE[apiKey] = key.id
+  API_KEY_CONTEXT = apiKey
 
   await incrementKeyUsage(key.id)
   return

--- a/libs/api/utils/src/lib/api-utils.ts
+++ b/libs/api/utils/src/lib/api-utils.ts
@@ -1,6 +1,5 @@
-import { prisma } from '@nmit-coursition/db'
+import { Prisma, prisma } from '@nmit-coursition/db'
 import { isDateBeforeNow } from '@nmit-coursition/utils'
-import { Prisma } from '@prisma/client'
 import { parseApiKey } from '../api'
 import type { ApiErrorCode } from '../errorList'
 import type { ApiKeyReportUsageRequest, ApiUsageReport, ApiUsageRequest } from '../typescript'
@@ -73,7 +72,7 @@ export async function computeUsage(r: ApiUsageRequest): Promise<ApiUsageReport[]
      COUNT(u.spend) AS operations
    FROM core__api_key_usage u
    WHERE u.key_id IN (${Prisma.join(keyIds)})
-   GROUP BY u.operation_class`;
+   GROUP BY u.operation_class`
 
   return spendRaw.map(
     (record): ApiUsageReport => ({
@@ -94,7 +93,7 @@ async function resolveUsageKeyIds(r: ApiUsageRequest): Promise<bigint[]> {
       ...('userId' in r ? { user_id: r.userId } : {}),
       ...('organisationId' in r ? { organisation_id: r.organisationId } : {}),
     },
-  });
+  })
 
   return keyListRaw.map((key) => key.id)
 }

--- a/libs/api/utils/src/typescript.ts
+++ b/libs/api/utils/src/typescript.ts
@@ -1,6 +1,19 @@
+export type OperationClass = 'A' | 'B' | 'C'
+
 export interface ApiKeyReportUsageRequest {
   apiKey?: string
-  operationClass?: 'A' | 'B' | 'C'
+  operationClass?: OperationClass
   spend?: number | bigint
   metaData?: object
+}
+
+export interface ApiUsageReport {
+  operation: OperationClass
+  spend: number
+  operations: number
+}
+
+export type ApiUsageRequest = ({ organisationId: number } | { userId: number } | { apiKey: string }) & {
+  dateFrom?: Date
+  dateTo: Date
 }

--- a/libs/api/utils/src/typescript.ts
+++ b/libs/api/utils/src/typescript.ts
@@ -1,5 +1,5 @@
 export interface ApiKeyReportUsageRequest {
-  apiKey: string
+  apiKey?: string
   operationClass?: 'A' | 'B' | 'C'
   spend?: number | bigint
   metaData?: object

--- a/libs/api/utils/src/typescript.ts
+++ b/libs/api/utils/src/typescript.ts
@@ -15,5 +15,5 @@ export interface ApiUsageReport {
 
 export type ApiUsageRequest = ({ organisationId: number } | { userId: number } | { apiKey: string }) & {
   dateFrom?: Date
-  dateTo: Date
+  dateTo?: Date
 }

--- a/libs/api/utils/src/typescript.ts
+++ b/libs/api/utils/src/typescript.ts
@@ -1,0 +1,6 @@
+export interface ApiKeyReportUsageRequest {
+  apiKey: string
+  operationClass?: 'A' | 'B' | 'C'
+  spend?: number | bigint
+  metaData?: object
+}

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -9,5 +9,6 @@ declare const globalThis: {
 } & typeof global
 
 export const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
+export { Prisma } from '@prisma/client'
 
 if (process.env['NODE_ENV'] !== 'production') globalThis.prismaGlobal = prisma

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -8,16 +8,6 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
-enum PaymentStatus {
-  FREE
-  LIFETIME
-}
-
-enum AuthProvider {
-  Google
-  Credentials
-}
-
 model User {
   id            String        @id @default(cuid())
   name          String?
@@ -31,7 +21,6 @@ model User {
   paymentStatus PaymentStatus @default(FREE)
   accounts      Account[]
   sessions      Session[]
-  PasswordReset PasswordReset[]
 }
 
 model Account {
@@ -51,17 +40,6 @@ model Account {
   user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([provider, providerAccountId])
-}
-
-model PasswordReset {
-  id         String   @id
-  secret     String   @unique
-  expires_at DateTime
-  is_used    Boolean  @default(false)
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
-  userId     String
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Session {
@@ -96,19 +74,20 @@ model cas__organisation {
 }
 
 model cas__organisation_api_key {
-  id                BigInt            @id(map: "cas__organisation_api_key_pk") @default(autoincrement())
-  organisation_id   Int
-  api_key           String            @unique(map: "cas__organisation_api_key_api_key_uindex") @db.Char(32)
-  used_count_today  BigInt
-  user_id           BigInt
-  is_active         Boolean
-  is_deleted        Boolean
-  description       String?
-  inserted_date     DateTime          @db.Timestamp(6)
-  expiration_date   DateTime          @db.Timestamp(6)
-  last_used_date    DateTime          @db.Timestamp(6)
-  cas__organisation cas__organisation @relation(fields: [organisation_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "cas__organisation_api_key_cas__organisation_id_fk")
-  cas__user         cas__user         @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "cas__organisation_api_key_cas__user_id_fk")
+  id                  BigInt                @id(map: "cas__organisation_api_key_pk") @default(autoincrement())
+  organisation_id     Int
+  api_key             String                @unique(map: "cas__organisation_api_key_api_key_uindex") @db.Char(32)
+  used_count_today    BigInt
+  user_id             BigInt
+  is_active           Boolean
+  is_deleted          Boolean
+  description         String?
+  inserted_date       DateTime              @db.Timestamp(6)
+  expiration_date     DateTime              @db.Timestamp(6)
+  last_used_date      DateTime              @db.Timestamp(6)
+  cas__organisation   cas__organisation     @relation(fields: [organisation_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "cas__organisation_api_key_cas__organisation_id_fk")
+  cas__user           cas__user             @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "cas__organisation_api_key_cas__user_id_fk")
+  core__api_key_usage core__api_key_usage[]
 
   @@index([organisation_id], map: "cas__organisation_api_key_organisation_id_index")
 }
@@ -122,4 +101,33 @@ model cas__user {
   synced_date               DateTime                    @db.Timestamp(6)
   cas__organisation_api_key cas__organisation_api_key[]
   cas__organisation         cas__organisation           @relation(fields: [organisation_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "cas__user_cas__organisation_id_fk")
+}
+
+model core__api_key_usage {
+  id                        BigInt                    @id(map: "core__api_key_usage_pk") @default(autoincrement())
+  key_id                    BigInt
+  operation_class           operation_class_enum
+  spend                     Int                       @db.SmallInt
+  meta_data                 Json?
+  inserted_date             DateTime                  @db.Timestamp(6)
+  cas__organisation_api_key cas__organisation_api_key @relation(fields: [key_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "core__api_key_usage_cas__organisation_api_key_id_fk")
+
+  @@index([inserted_date], map: "core__api_key_usage_inserted_date_index")
+  @@index([key_id], map: "core__api_key_usage_key_id_index")
+}
+
+enum PaymentStatus {
+  FREE
+  LIFETIME
+}
+
+enum AuthProvider {
+  Google
+  Credentials
+}
+
+enum operation_class_enum {
+  A
+  B
+  C
 }

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -21,6 +21,7 @@ model User {
   paymentStatus PaymentStatus @default(FREE)
   accounts      Account[]
   sessions      Session[]
+  PasswordReset PasswordReset[]
 }
 
 model Account {
@@ -40,6 +41,17 @@ model Account {
   user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([provider, providerAccountId])
+}
+
+model PasswordReset {
+  id         String   @id
+  secret     String   @unique
+  expires_at DateTime
+  is_used    Boolean  @default(false)
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Session {


### PR DESCRIPTION
Track runned request and spend.

Sample usage:

```ts
.get('/ping', () => ({ status: 'PONG' }), {
  afterResponse: async ({ headers }) => {
    await reportSpend({ apiKey: headers.authorization })
  },
})
```

Or simply with default values and context:

```ts
.get('/ping', () => ({ status: 'PONG' }), {
  afterResponse: () => reportSpend({}),
})
```

It will report records like this:

<img width="974" alt="Snímek obrazovky 2024-09-22 v 12 54 17" src="https://github.com/user-attachments/assets/9a9d62b8-3c18-471b-867c-d32eacf09e6e">

And you can simply join to organisation and user by API key relations.